### PR TITLE
Ported Discord wiki to docs folder format, added warnings on deprecated functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GMEXT-Discord
-Repository for GameMaker's Discord Extension
+
+> **WARNING**: This extension makes use of the Discord [Game SDK](https://discord.com/developers/docs/developer-tools/game-sdk), which has been replaced by a [REST API](https://discord.com/developers/docs/reference). Several parts of functionality have been deprecated by Discord and may or may not work. See [https://discord.com/developers/docs/developer-tools/game-sdk](discord.com/developers/docs/developer-tools/game-sdk) for what's supported and what's no longer supported.
+
+This is the source repository for GameMaker's Discord Extension.
 
 This repository was created with the intent of presenting users with the latest version available of the extension (even previous to marketplace updates) and also provide a way for the community to contribute with bug fixes and feature implementation.
 

--- a/docs/Activities.js
+++ b/docs/Activities.js
@@ -1,0 +1,294 @@
+
+/**
+ * @module activities
+ * @title Activities
+ * 
+ * @section_func
+ * @ref Discord_Activities_UpdateActivity
+ * @ref Discord_Activities_AcceptInvite
+ * @ref Discord_Activities_ClearActivity
+ * @ref Discord_Activities_SendInvite
+ * @ref Discord_Activities_SendRequestReply
+ * @section_end
+ * 
+ * @section_struct
+ * @ref Activity
+ * @ref ActivityData
+ * @ref ActivityTimestamps
+ * @ref ActivityAssets
+ * @ref ActivityParty
+ * @ref ActivitySecrets
+ * @section_end
+ * 
+ * @section_const
+ * @ref Discord_ActivityType
+ * @ref Discord_ActivityActionType
+ * @ref Discord_ActivityJoinRequestReply
+ * @section_end
+ * 
+ * @module_end
+ */
+
+
+/**
+ * @function Discord_Activities_UpdateActivity
+ * @desc **Discord Function:** [UpdateActivity](https://discord.com/developers/docs/game-sdk/activities#updateactivity)
+ * 
+ * This function sets a user's presence in Discord to a new activity.
+ * 
+ * [[Info: It is possible for users to hide their presence on Discord (User Settings -> Game Activity). Presence set through this SDK may not be visible when this setting is toggled off.]]
+ * 
+ * [[Warning: This has a rate limit of 5 updates per 20 seconds.]]
+ * 
+ * @param {struct.activityData} The data to be applied to the user's activity
+ * 
+ * @event social
+ * @member {string} type The string `"Discord_Activities_UpdateActivity"`
+ * @member {real} result Result code of the async request.
+ * @member {bool} Whether the current request was successful or not.
+ * @event_end
+ * 
+ * @example
+ * ```gml
+ * Discord_Activity_UpdateActivity({
+ *    state: "Creating Games",
+ *    type: Discord_Activity_Type_Playing,
+ *    details: "Details...",
+ *    smallImage: "mySmallImageName",
+ *    smallText: "mySmallText",
+ *    largeImage: "myLargeImageName",
+ *    largeText: "myLargeText"
+ * });
+ * ```
+ * The code sample above saves the identifier that can be used inside an ${event.social}.
+ * 
+ * ```gml
+ * if (async_load[? "type"] == "Discord_Activity_UpdateActivity")
+ * {
+ *     if (async_load[? "result"] == Discord_OK)
+ *     {
+ *         show_debug_message(async_load[? "type"] + " succeeded!");
+ *     }
+ *     else
+ *     {
+ *         show_debug_message(async_load[? "type"] + " failed!");
+ *     }
+ * }
+ * ```
+ * The code above matches the response against the correct event **type** and logs the success of the task.
+ * @func_end
+ */
+
+
+/**
+ * @function Discord_Activities_AcceptInvite
+ * @desc **Discord Function:** [AcceptInvite](https://discord.com/developers/docs/game-sdk/activities#acceptinvite)
+ * 
+ * This function accepts a game invitation from a given userId.
+ * 
+ * @param {int64} userId The ID of the user who invited you
+ * 
+ * @event social
+ * @member {string} type The string `"Discord_Activities_AcceptInvite"`
+ * @member {real} result Result code of the async request.
+ * @member {bool} success Whether the current request was successful or not.
+ * @event_end
+ * 
+ * @example 
+ * ```gml
+ * Discord_Activities_AcceptInvite(userId);
+ * ```
+ * @func_end
+ */
+
+
+/**
+ * @function Discord_Activities_ClearActivity
+ * @desc **Discord Function:** [ClearActivity](https://discord.com/developers/docs/game-sdk/activities#clearactivity)
+ * 
+ * This function clears a user's presence in Discord to make it show nothing.
+ * 
+ * @event social
+ * @member {string} type The string `"Discord_Activities_ClearActivity"`
+ * @member {real} result Result code of the async request.
+ * @member {bool} success Whether the current request was successful or not.
+ * @event_end
+ * 
+ * @example 
+ * ```gml
+ * Discord_Activities_ClearActivity();
+ * ```
+ * @func_end
+ */
+
+
+/**
+ * @function Discord_Activities_SendInvite
+ * @desc **Discord Function:** [SendInvite](https://discord.com/developers/docs/game-sdk/activities#sendinvite)
+ * 
+ * This function sends a game invite to a given user. If you do not have a valid activity with all the required fields, this call will error. See [Activity Action Field Requirements](https://discord.com/developers/docs/game-sdk/activities#activity-action-field-requirements) for the fields required to have join and spectate invites function properly.
+ * 
+ * @param {int64} userId the ID of the user to invite
+ * @param {constant.ActivityActionType} type marks the invite as an invitation to join or spectate
+ * @param {string} content a message to send along with the invite
+ * 
+ * @event social
+ * @member {string} type The string `"Discord_Activities_SendInvite"`
+ * @member {real} result Result code of the async request.
+ * @member {bool} success Whether the current request was successful or not.
+ * @event_end
+ * 
+ * @example 
+ * ```gml
+ * Discord_Activities_SendInvite(otherUserId, Discord_ActivityActionType_Join, "Come join my awesome game!");
+ * ```
+ * @func_end
+ */
+
+
+/**
+ * @function Discord_Activities_SendRequestReply
+ * @desc **Discord Function:** [SendRequestReply](https://discord.com/developers/docs/game-sdk/activities#sendrequestreply)
+ * 
+ * This function sends a reply to an Ask to Join request.
+ * 
+ * @param {int64} userId The user ID of the person who asked to join
+ * @param {constant.ActivityJoinRequestReply} reply No, Yes or Ignore
+ * @event social
+ * @member {string} type The string `"Discord_Activities_SendRequestReply"`
+ * @member {real} result Result code of the async request.
+ * @member {bool}  Whether the current request was successful or not.
+ * @event_end
+ * 
+ * @example 
+ * ```gml
+ * Discord_Activities_SendRequestReply(otherUserId, Discord_ActivityJoinRequestReply_Yes);
+ * ```
+ * @func_end
+ */
+
+
+// Structs
+
+/**
+ * @struct Activity
+ * @desc **Discord Struct:** [Activity Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-activity-struct)
+ * 
+ * The `Activity` struct contains information about a user's current activity, including the application ID, name of the application, current party status, what the player is currently doing, timestamps, assets to display on the player's profile, party information, and secret passwords for joining and spectating the player's game.
+ * 
+ * @member {int64} applicationId Your application ID. This is a read-only field.
+ * @member {string} name Name of the application. This is a read-only field.
+ * @member {string} state The player's current party status.
+ * @member {string} details What the player is currently doing.
+ * @member {struct.ActivityTimestamps} timestamps Helps create elapsed/remaining timestamps on a player's profile.
+ * @member {struct.ActivityAssets} assets Assets to display on the player's profile.
+ * @member {struct.ActivityParty} party Information about the player's party.
+ * @member {struct.ActivitySecrets} secrets Secret passwords for joining and spectating the player's game.
+ * @member {bool} instance Whether this activity is an instanced context, like a match.
+ * @struct_end
+ */
+
+
+/**
+ * @struct ActivityTimestamps
+ * @desc **Discord Struct:** [ActivityTimestamps Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-activitytimestamps-struct)
+ * 
+ * The `ActivityTimestamps` struct is used to create elapsed/remaining timestamps on a player's profile. It contains two fields: `startTimestamp` and `endTimestamp`, both of which are Unix timestamps.
+ * 
+ * @member {int64} startTimestamp Unix timestamp - send this to have an "elapsed" timer
+ * @member {int64} endTimestamp Unix timestamp - send this to have a "remaining" timer
+ * @struct_end
+ */
+
+
+/**
+ * @struct ActivityAssets
+ * @desc **Discord Struct:** [ActivityAssets Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-activityassets-struct)
+ * 
+ * The `ActivityAssets` struct contains assets to display on a player's profile, including both large and small images and corresponding hover text.
+ * 
+ * @member {string} largeImage The key for the large image asset
+ * @member {string} largeText The text to display when hovering over the asset
+ * @member {string} smallImage The key for the small image asset
+ * @member {string} smallText The text to display when hovering over the asset
+ * @struct_end
+ */
+
+
+/**
+ * @struct ActivityParty
+ * @desc **Discord Struct:** [ActivityParty Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-activityparty-struct)
+ * 
+ * The `ActivityParty` struct contains information about the player's party, including a unique identifier and party size.
+ * 
+ * @member {string} id A unique identifier for this party
+ * @member {struct.PartySize} size Info about the size of the party
+ * @struct_end
+ */
+
+
+/**
+ * @struct PartySize
+ * @desc **Discord Struct:** [PartySize Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-partysize-struct)
+ * 
+ * The `PartySize` struct contains information about the size of a party, including both the current size and maximum possible size.
+ * 
+ * @member {int32} currentSize The current size of the party.
+ * @member {int32} maxSize The max possible size of the party.
+ * @struct_end
+ */
+
+
+/**
+ * @struct ActivitySecrets
+ * @desc **Discord Struct:** [ActivitySecrets Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-activitysecrets-struct)
+ * 
+ * The `ActivitySecrets` struct contains secret passwords for joining and spectating the player's game, as well as a unique hash for the given match context.
+ * 
+ * @member {string} match unique hash for the given match context
+ * @member {string} join unique hash for chat invites and Ask to Join
+ * @member {string} spectate unique hash for Spectate button
+ * @struct_end
+ */
+
+// Constants
+
+/**
+ * @constant Discord_ActivityType
+ * @desc **Discord Enum:** [ActivityType Enum](https://discord.com/developers/docs/game-sdk/activities#data-models-activitytype-enum)
+ * 
+ * This represents the type of a user activity and is to be used with [`Discord_Activities_UpdateActivity`](#discord_activities_updateactivity).
+ * 
+ * @member Discord_ActivityType_Playing 0 Represents the playing activity type; useful when user is playing games.
+ * @member Discord_ActivityType_Streaming 1 Represents the streaming activity type; useful when user is streaming on discord, twitch or other platforms.
+ * @member Discord_ActivityType_Listening 2 Represents the listening activity type; useful when user is listening to music on Spotify or other platforms.
+ * @member Discord_ActivityType_Watching 3 Represents the watching activity type; useful when user is watching their favorite shows.
+ * @member Discord_ActivityType_Custom 4 Represents any custom activity type
+ * @member Discord_ActivityType_Competing 5 Represents the competing activity type
+ * @constant_end
+ */
+
+
+/**
+ * @constant Discord_ActivityActionType
+ * @desc **Discord Enum:** [ActivityActionType Enum](https://discord.com/developers/docs/game-sdk/activities#data-models-activityactiontype-enum)
+ * 
+ * This represents the type of activity action and is to be used with [`Discord_Overlay_OpenActivityInvite`](Overlay#discord_overlay_openactivityinvite).
+ * 
+ * @member Discord_ActivityActionType_Join 1 Represents the action of joining an activity.
+ * @member Discord_ActivityActionType_Spectate 2 Represents the action of spectating an activity.
+ * @constant_end
+ */
+
+
+/**
+ * @constant Discord_ActivityJoinRequestReply
+ * @desc **Discord Enum:** [ActivityJoinRequestReply Enum](https://discord.com/developers/docs/game-sdk/activities#data-models-activityjoinrequestreply-enum)
+ * 
+ * This enum provides options for how to respond to a user's request to join an activity.
+ * 
+ * @member Discord_ActivityJoinRequestReply_No 0 Do not join
+ * @member Discord_ActivityJoinRequestReply_Yes 1 Join
+ * @member Discord_ActivityJoinRequestReply_Ignore 2 Ignore the join request
+ * @constant_end
+ */

--- a/docs/Activities.js
+++ b/docs/Activities.js
@@ -2,6 +2,7 @@
 /**
  * @module activities
  * @title Activities
+ * @desc **Discord SDK:** [Activities](https://discord.com/developers/docs/developer-tools/game-sdk#activities)
  * 
  * @section_func
  * @ref Discord_Activities_UpdateActivity
@@ -33,7 +34,7 @@
 
 /**
  * @function Discord_Activities_UpdateActivity
- * @desc **Discord Function:** [UpdateActivity](https://discord.com/developers/docs/game-sdk/activities#updateactivity)
+ * @desc **Discord Function:** [UpdateActivity](https://discord.com/developers/docs/developer-tools/game-sdk#updateactivity)
  * 
  * This function sets a user's presence in Discord to a new activity.
  * 
@@ -41,17 +42,17 @@
  * 
  * [[Warning: This has a rate limit of 5 updates per 20 seconds.]]
  * 
- * @param {struct.Activity} The data to be applied to the user's activity
+ * @param {struct.Activity} activity The data to be applied to the user's activity
  * 
  * @event social
  * @member {string} type The string `"Discord_Activities_UpdateActivity"`
  * @member {real} result Result code of the async request.
- * @member {bool} Whether the current request was successful or not.
+ * @member {bool} success Whether the current request was successful or not.
  * @event_end
  * 
  * @example
  * ```gml
- * Discord_Activity_UpdateActivity({
+ * identifier = Discord_Activity_UpdateActivity({
  *    state: "Creating Games",
  *    type: Discord_Activity_Type_Playing,
  *    details: "Details...",
@@ -61,7 +62,7 @@
  *    largeText: "myLargeText"
  * });
  * ```
- * The code sample above saves the identifier that can be used inside an ${event.social}.
+ * The code sample above saves the identifier that can be used to differentiate between two requests in the ${event.social}.
  * 
  * ```gml
  * if (async_load[? "type"] == "Discord_Activity_UpdateActivity")
@@ -83,7 +84,7 @@
 
 /**
  * @function Discord_Activities_AcceptInvite
- * @desc **Discord Function:** [AcceptInvite](https://discord.com/developers/docs/game-sdk/activities#acceptinvite)
+ * @desc **Discord Function:** [AcceptInvite](https://discord.com/developers/docs/developer-tools/game-sdk#acceptinvite)
  * 
  * This function accepts a game invitation from a given userId.
  * 
@@ -105,7 +106,7 @@
 
 /**
  * @function Discord_Activities_ClearActivity
- * @desc **Discord Function:** [ClearActivity](https://discord.com/developers/docs/game-sdk/activities#clearactivity)
+ * @desc **Discord Function:** [ClearActivity](https://discord.com/developers/docs/developer-tools/game-sdk#clearactivity)
  * 
  * This function clears a user's presence in Discord to make it show nothing.
  * 
@@ -125,7 +126,7 @@
 
 /**
  * @function Discord_Activities_SendInvite
- * @desc **Discord Function:** [SendInvite](https://discord.com/developers/docs/game-sdk/activities#sendinvite)
+ * @desc **Discord Function:** [SendInvite](https://discord.com/developers/docs/developer-tools/game-sdk#sendinvite)
  * 
  * This function sends a game invite to a given user. If you do not have a valid activity with all the required fields, this call will error. See [Activity Action Field Requirements](https://discord.com/developers/docs/game-sdk/activities#activity-action-field-requirements) for the fields required to have join and spectate invites function properly.
  * 
@@ -149,12 +150,12 @@
 
 /**
  * @function Discord_Activities_SendRequestReply
- * @desc **Discord Function:** [SendRequestReply](https://discord.com/developers/docs/game-sdk/activities#sendrequestreply)
+ * @desc **Discord Function:** [SendRequestReply](https://discord.com/developers/docs/developer-tools/game-sdk#sendrequestreply)
  * 
  * This function sends a reply to an Ask to Join request.
  * 
  * @param {int64} userId The user ID of the person who asked to join
- * @param {constant.Discord_ActivityJoinRequestReply} reply No, Yes or Ignore
+ * @param {constant.Discord_ActivityJoinRequestReply} reply `Discord_ActivityJoinRequestReply_No`, `Discord_ActivityJoinRequestReply_Yes` or `Discord_ActivityJoinRequestReply_Ignore`
  * @event social
  * @member {string} type The string `"Discord_Activities_SendRequestReply"`
  * @member {real} result Result code of the async request.
@@ -173,7 +174,7 @@
 
 /**
  * @struct Activity
- * @desc **Discord Struct:** [Activity Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-activity-struct)
+ * @desc **Discord Struct:** [Activity Struct](https://discord.com/developers/docs/developer-tools/game-sdk#activity-struct)
  * 
  * The `Activity` struct contains information about a user's current activity, including the application ID, name of the application, current party status, what the player is currently doing, timestamps, assets to display on the player's profile, party information, and secret passwords for joining and spectating the player's game.
  * 
@@ -192,7 +193,7 @@
 
 /**
  * @struct ActivityTimestamps
- * @desc **Discord Struct:** [ActivityTimestamps Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-activitytimestamps-struct)
+ * @desc **Discord Struct:** [ActivityTimestamps Struct](https://discord.com/developers/docs/developer-tools/game-sdk#activitytimestamps-struct)
  * 
  * The `ActivityTimestamps` struct is used to create elapsed/remaining timestamps on a player's profile. It contains two fields: `startTimestamp` and `endTimestamp`, both of which are Unix timestamps.
  * 
@@ -204,7 +205,7 @@
 
 /**
  * @struct ActivityAssets
- * @desc **Discord Struct:** [ActivityAssets Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-activityassets-struct)
+ * @desc **Discord Struct:** [ActivityAssets Struct](https://discord.com/developers/docs/developer-tools/game-sdk#activityassets-struct)
  * 
  * The `ActivityAssets` struct contains assets to display on a player's profile, including both large and small images and corresponding hover text.
  * 
@@ -218,7 +219,7 @@
 
 /**
  * @struct ActivityParty
- * @desc **Discord Struct:** [ActivityParty Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-activityparty-struct)
+ * @desc **Discord Struct:** [ActivityParty Struct](https://discord.com/developers/docs/developer-tools/game-sdk#activityparty-struct)
  * 
  * The `ActivityParty` struct contains information about the player's party, including a unique identifier and party size.
  * 
@@ -230,7 +231,7 @@
 
 /**
  * @struct PartySize
- * @desc **Discord Struct:** [PartySize Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-partysize-struct)
+ * @desc **Discord Struct:** [PartySize Struct](https://discord.com/developers/docs/developer-tools/game-sdk#partysize-struct)
  * 
  * The `PartySize` struct contains information about the size of a party, including both the current size and maximum possible size.
  * 
@@ -242,7 +243,7 @@
 
 /**
  * @struct ActivitySecrets
- * @desc **Discord Struct:** [ActivitySecrets Struct](https://discord.com/developers/docs/game-sdk/activities#data-models-activitysecrets-struct)
+ * @desc **Discord Struct:** [ActivitySecrets Struct](https://discord.com/developers/docs/developer-tools/game-sdk#activitysecrets-struct)
  * 
  * The `ActivitySecrets` struct contains secret passwords for joining and spectating the player's game, as well as a unique hash for the given match context.
  * 
@@ -256,7 +257,7 @@
 
 /**
  * @constant Discord_ActivityType
- * @desc **Discord Enum:** [ActivityType Enum](https://discord.com/developers/docs/game-sdk/activities#data-models-activitytype-enum)
+ * @desc **Discord Enum:** [ActivityType Enum](https://discord.com/developers/docs/developer-tools/game-sdk#activitytype-enum)
  * 
  * This represents the type of a user activity and is to be used with [`Discord_Activities_UpdateActivity`](#discord_activities_updateactivity).
  * 
@@ -272,7 +273,7 @@
 
 /**
  * @constant Discord_ActivityActionType
- * @desc **Discord Enum:** [ActivityActionType Enum](https://discord.com/developers/docs/game-sdk/activities#data-models-activityactiontype-enum)
+ * @desc **Discord Enum:** [ActivityActionType Enum](https://discord.com/developers/docs/developer-tools/game-sdk#activityactiontype-enum)
  * 
  * This represents the type of activity action and is to be used with [`Discord_Overlay_OpenActivityInvite`](Overlay#discord_overlay_openactivityinvite).
  * 
@@ -284,7 +285,7 @@
 
 /**
  * @constant Discord_ActivityJoinRequestReply
- * @desc **Discord Enum:** [ActivityJoinRequestReply Enum](https://discord.com/developers/docs/game-sdk/activities#data-models-activityjoinrequestreply-enum)
+ * @desc **Discord Enum:** [ActivityJoinRequestReply Enum](https://discord.com/developers/docs/developer-tools/game-sdk#activityjoinrequestreply-enum)
  * 
  * This enum provides options for how to respond to a user's request to join an activity.
  * 

--- a/docs/Activities.js
+++ b/docs/Activities.js
@@ -18,6 +18,7 @@
  * @ref ActivityAssets
  * @ref ActivityParty
  * @ref ActivitySecrets
+ * @ref PartySize
  * @section_end
  * 
  * @section_const
@@ -40,7 +41,7 @@
  * 
  * [[Warning: This has a rate limit of 5 updates per 20 seconds.]]
  * 
- * @param {struct.activityData} The data to be applied to the user's activity
+ * @param {struct.Activity} The data to be applied to the user's activity
  * 
  * @event social
  * @member {string} type The string `"Discord_Activities_UpdateActivity"`
@@ -129,7 +130,7 @@
  * This function sends a game invite to a given user. If you do not have a valid activity with all the required fields, this call will error. See [Activity Action Field Requirements](https://discord.com/developers/docs/game-sdk/activities#activity-action-field-requirements) for the fields required to have join and spectate invites function properly.
  * 
  * @param {int64} userId the ID of the user to invite
- * @param {constant.ActivityActionType} type marks the invite as an invitation to join or spectate
+ * @param {constant.Discord_ActivityActionType} type marks the invite as an invitation to join or spectate
  * @param {string} content a message to send along with the invite
  * 
  * @event social
@@ -153,7 +154,7 @@
  * This function sends a reply to an Ask to Join request.
  * 
  * @param {int64} userId The user ID of the person who asked to join
- * @param {constant.ActivityJoinRequestReply} reply No, Yes or Ignore
+ * @param {constant.Discord_ActivityJoinRequestReply} reply No, Yes or Ignore
  * @event social
  * @member {string} type The string `"Discord_Activities_SendRequestReply"`
  * @member {real} result Result code of the async request.
@@ -233,8 +234,8 @@
  * 
  * The `PartySize` struct contains information about the size of a party, including both the current size and maximum possible size.
  * 
- * @member {int32} currentSize The current size of the party.
- * @member {int32} maxSize The max possible size of the party.
+ * @member {real} currentSize The current size of the party.
+ * @member {real} maxSize The max possible size of the party.
  * @struct_end
  */
 

--- a/docs/Core.js
+++ b/docs/Core.js
@@ -1,0 +1,91 @@
+
+/**
+ * @module core
+ * @title Core
+ * @desc **Discord SDK:** [Discord](https://discord.com/developers/docs/game-sdk/discord)
+ * 
+ * @section_func
+ * @ref Discord_Core_Create
+ * @ref Discord_Core_RunCallbacks
+ * @section_end
+ * 
+ * @section_const
+ * @ref Discord_Result
+ * @ref Discord_CreateFlags
+ * @section_end
+ * 
+ * @module_end
+ */
+
+// Functions
+
+/**
+ * @function Discord_Core_Create
+ * @desc *Discord Function*: [Core::Create](https://discord.com/developers/docs/game-sdk/discord#create)
+ * 
+ * This function initialises the Discord extension and returns whether this was successful.
+ * The `creationFlag` parameter determines if the Discord extension requires or doesn't require Discord to be running. If the optional `creationFlag` is set to `Discord_CreateFlags_Default` (the default value) and Discord is not running, it will:
+ * 
+ *   1. Close your game
+ *   2. Open Discord
+ *   3. Attempt to re-open your game
+ * 
+ * @param {int64} appId  Application identifier
+ * @param {constant.Discord_CreateFlags} [creationFlag] `Discord_CreateFlags_Default` or `Discord_CreateFlags_NoRequireDiscord`
+ * 
+ * @returns {bool}
+ * @example
+ * ```gml
+ * if(!Discord_Core_Create(_applicationId, Discord_CreateFlags_Default))
+ * {
+ *     show_message_async("Discord Initialisation Error");
+ *     exit;
+ * }
+ * ```
+ * @func_end
+ */
+
+/**
+ * @function Discord_Core_RunCallbacks
+ * @desc **Discord Function:** [RunCallbacks](https://discord.com/developers/docs/game-sdk/discord#runcallbacks)
+ * 
+ * This function requests the extension instances to do work.
+ * 
+ * [[Warning: It is imperative that this function is called at regular intervals to ensure that all the services offered by the SDK function optimally.]]
+ * 
+ * @event social
+ * @desc This async event is triggered whenever the user struct of the currently connected user changes. They may have changed their avatar, username, or something else.
+ * 
+ * @member {real} result Result code of the async request
+ * @member {string} type The string `"Discord_Users_OnCurrentUserUpdate"`
+ * @event_end
+ * 
+ * @example
+ * ```gml
+ * /// Step Event
+ * Discord_Core_RunCallbacks();
+ * ```
+ * 
+ * @func_end
+ */
+
+// Constants
+
+/**
+ * @constant Discord_Result
+ * @desc **Discord Enum:** [Result Enum](https://discord.com/developers/docs/game-sdk/discord#data-models-result-enum)
+ * 
+ * @member Discord_OK 0 A constant that indicates that the result is OK
+ * 
+ * @constant_end
+ */
+
+/**
+ * @constant Discord_CreateFlags
+ * @desc **Discord Enum:** [CreateFlags Enum](https://discord.com/developers/docs/game-sdk/discord#data-models-createflags-enum)
+ * 
+ * @member Discord_CreateFlags_Default 0 Requires Discord to be running to play the game
+ * @member Discord_CreateFlags_NoRequireDiscord 1 Requires Discord to be running to play the game
+ * 
+ * @constant_end
+ */

--- a/docs/Core.js
+++ b/docs/Core.js
@@ -21,7 +21,7 @@
 
 /**
  * @function Discord_Core_Create
- * @desc *Discord Function*: [Core::Create](https://discord.com/developers/docs/game-sdk/discord#create)
+ * @desc **Discord Function:** [Create](https://discord.com/developers/docs/developer-tools/game-sdk#create)
  * 
  * This function initialises the Discord extension and returns whether this was successful.
  * The `creationFlag` parameter determines if the Discord extension requires or doesn't require Discord to be running. If the optional `creationFlag` is set to `Discord_CreateFlags_Default` (the default value) and Discord is not running, it will:
@@ -31,7 +31,7 @@
  *   3. Attempt to re-open your game
  * 
  * @param {int64} appId  Application identifier
- * @param {constant.Discord_CreateFlags} [creationFlag] `Discord_CreateFlags_Default` or `Discord_CreateFlags_NoRequireDiscord`
+ * @param {constant.Discord_CreateFlags} [creationFlag=Discord_CreateFlags_Default] `Discord_CreateFlags_Default` or `Discord_CreateFlags_NoRequireDiscord`
  * 
  * @returns {bool}
  * @example
@@ -47,7 +47,7 @@
 
 /**
  * @function Discord_Core_RunCallbacks
- * @desc **Discord Function:** [RunCallbacks](https://discord.com/developers/docs/game-sdk/discord#runcallbacks)
+ * @desc **Discord Function:** [RunCallbacks](https://discord.com/developers/docs/developer-tools/game-sdk#runcallbacks)
  * 
  * This function requests the extension instances to do work.
  * 
@@ -73,7 +73,7 @@
 
 /**
  * @constant Discord_Result
- * @desc **Discord Enum:** [Result Enum](https://discord.com/developers/docs/game-sdk/discord#data-models-result-enum)
+ * @desc **Discord Enum:** [Result Enum](https://discord.com/developers/docs/developer-tools/game-sdk#result-enum)
  * 
  * @member Discord_OK 0 A constant that indicates that the result is OK
  * 
@@ -82,10 +82,10 @@
 
 /**
  * @constant Discord_CreateFlags
- * @desc **Discord Enum:** [CreateFlags Enum](https://discord.com/developers/docs/game-sdk/discord#data-models-createflags-enum)
+ * @desc **Discord Enum:** [CreateFlags Enum](https://discord.com/developers/docs/developer-tools/game-sdk#createflags-enum)
  * 
  * @member Discord_CreateFlags_Default 0 Requires Discord to be running to play the game
- * @member Discord_CreateFlags_NoRequireDiscord 1 Requires Discord to be running to play the game
+ * @member Discord_CreateFlags_NoRequireDiscord 1 Does not require Discord to be running, use this on other platforms
  * 
  * @constant_end
  */

--- a/docs/Docs.js
+++ b/docs/Docs.js
@@ -1,14 +1,19 @@
 /**
- * @module Home
+ * @module home
+ * @title Discord
  * @desc Welcome to the Discord extension wiki!
  * 
  * On this wiki you can find the reference for the Discord extension for GameMaker and a guide to get started with it.
  * 
+ * [[Warning: This Discord extension currently still uses the legacy [Game SDK](https://discord.com/developers/docs/developer-tools/game-sdk), which has been replaced by a [REST API](https://discord.com/developers/docs/reference). Several parts of functionality have been deprecated by Discord and may or may not work. See [https://discord.com/developers/docs/developer-tools/game-sdk](discord.com/developers/docs/developer-tools/game-sdk) for what's supported and what's no longer supported.]]
+ * 
  * @section Guides
- * @ref page.Quick_Start_Guide
+ * @desc These are the guides for the Discord extension: 
+ * @ref page.quick_start_guide
  * @section_end
  * 
  * @section Modules
+ * @desc The following are the modules of the Discord extension: 
  * @ref module.core
  * @ref module.overlay
  * @ref module.users

--- a/docs/Docs.js
+++ b/docs/Docs.js
@@ -1,0 +1,21 @@
+/**
+ * @module Home
+ * @desc Welcome to the Discord extension wiki!
+ * 
+ * On this wiki you can find the reference for the Discord extension for GameMaker and a guide to get started with it.
+ * 
+ * @section Guides
+ * @ref page.Quick_Start_Guide
+ * @section_end
+ * 
+ * @section Modules
+ * @ref module.core
+ * @ref module.overlay
+ * @ref module.users
+ * @ref module.activities
+ * @ref module.relationships
+ * @ref module.images
+ * @section_end
+ * 
+ * @module_end
+ */

--- a/docs/Images.js
+++ b/docs/Images.js
@@ -2,6 +2,10 @@
 /**
  * @module images
  * @title Images
+ * @desc **Discord SDK:** [Images](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Images.md)
+ * 
+ * [[Warning: The Game SDK's Images functionality has been deprecated by Discord.]]
+ * 
  * @section_func
  * @ref Discord_Images_Fetch
  * @section_end
@@ -12,7 +16,7 @@
 
 /**
  * @function Discord_Images_Fetch
- * @desc **Discord Function:** [Fetch](https://discord.com/developers/docs/game-sdk/images#fetch)
+ * @desc **Discord Function:** [Fetch](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Images.md#fetch)
  * 
  * This function prepares an image to later retrieve data about it.
  * 

--- a/docs/Images.js
+++ b/docs/Images.js
@@ -1,0 +1,60 @@
+
+/**
+ * @module images
+ * @title Images
+ * @section_func
+ * @ref Discord_Images_Fetch
+ * @section_end
+ * @module_end
+ */
+
+// Functions
+
+/**
+ * @function Discord_Images_Fetch
+ * @desc **Discord Function:** [Fetch](https://discord.com/developers/docs/game-sdk/images#fetch)
+ * 
+ * This function prepares an image to later retrieve data about it.
+ * 
+ * @param {int64} userId The ID of the user whose avatar you want to get.
+ * @param {real} size The resolution at which you want the image (needs to be a power of 2)
+ * 
+ * @event social
+ * @member {string} type `"Discord_Images_Fetch"`
+ * @member {real} result Result code of the async request.
+ * @member {bool} success Whether the current request was successful or not.
+ * @member {int64} userId The ID of the user whose avatar you requested.
+ * @member {real} width The width of the avatar image
+ * @member {real} height The height of the avatar image
+ * @member {type.buffer} buffer A buffer containing the avatar image data.
+ * @event_end
+ * 
+ * @example
+ * ```gml
+ * /// Create Event
+ * Discord_Images_Fetch(userId, 64);
+ * 
+ * /// Async Event
+ * if(async_load[?"result"] != Discord_OK)
+ * {
+ *     exit;
+ * }
+ * 
+ * switch(async_load[?"type"])
+ * {
+ *     case "Discord_Images_Fetch":
+ *         
+ *         // If user ids don't match bail
+ *         if (userId != async_load[?"userId"]) exit;
+ *         
+ *         var buffer = async_load[?"buffer"];
+ *     
+ *         surf = surface_create(async_load[?"width"], async_load[?"height"]);
+ *         buffer_set_surface(buffer, surf, 0);
+ *     
+ *         buffer_delete(buffer);
+ *         break;
+ * }
+ * ```
+ * @func_end
+ */

--- a/docs/Overlay.js
+++ b/docs/Overlay.js
@@ -24,7 +24,7 @@
  * 
  * This function opens the overlay modal for sending game invitations to users, channels, and servers. If you do not have a valid activity with all the required fields, this call will error. See [Activity Action Field Requirements](https://discord.com/developers/docs/game-sdk/activities#activity-action-field-requirements) for the fields required to have join and spectate invites function properly.
  * 
- * @param {Discord_ActivityActionType} value What type of invite to send
+ * @param {constant.Discord_ActivityActionType} value What type of invite to send
  * 
  * @example 
  * ```gml

--- a/docs/Overlay.js
+++ b/docs/Overlay.js
@@ -1,7 +1,7 @@
 /**
  * @module overlay
  * @title Overlay
- * @desc **Discord SDK:** [Overlay](https://discord.com/developers/docs/game-sdk/overlay)
+ * @desc **Discord SDK:** [Overlay](https://discord.com/developers/docs/developer-tools/game-sdk#overlay)
  * 
  * @section_func
  * @ref Discord_Overlay_OpenActivityInvite
@@ -20,7 +20,7 @@
 
 /**
  * @function Discord_Overlay_OpenActivityInvite
- * @desc **Discord Function:** [OpenActivityInvite](https://discord.com/developers/docs/game-sdk/overlay#openactivityinvite)
+ * @desc **Discord Function:** [OpenActivityInvite](https://discord.com/developers/docs/developer-tools/game-sdk#openactivityinvite)
  * 
  * This function opens the overlay modal for sending game invitations to users, channels, and servers. If you do not have a valid activity with all the required fields, this call will error. See [Activity Action Field Requirements](https://discord.com/developers/docs/game-sdk/activities#activity-action-field-requirements) for the fields required to have join and spectate invites function properly.
  * 
@@ -53,7 +53,7 @@
 
 /**
  * @function Discord_Overlay_IsEnabled
- * @desc **Discord Function:** [IsEnabled](https://discord.com/developers/docs/game-sdk/overlay#isenabled)
+ * @desc **Discord Function:** [IsEnabled](https://discord.com/developers/docs/developer-tools/game-sdk#isenabled)
  * 
  * This function checks whether the user has the overlay enabled or disabled. If the overlay is disabled, all the functionality in this manager will still work. The calls will instead focus the Discord client and show the modal there instead.
  * 
@@ -69,7 +69,7 @@
 
 /**
  * @function Discord_Overlay_IsLocked
- * @desc **Discord Function:** [IsLocked](https://discord.com/developers/docs/game-sdk/overlay#islocked)
+ * @desc **Discord Function:** [IsLocked](https://discord.com/developers/docs/developer-tools/game-sdk#islocked)
  * 
  * This function checks if the overlay is currently locked or unlocked.
  * 
@@ -85,7 +85,7 @@
 
 /**
  * @function Discord_Overlay_OpenGuildInvite
- * @desc **Discord Function:** [OpenGuildInvite](https://discord.com/developers/docs/game-sdk/overlay#openguildinvite)
+ * @desc **Discord Function:** [OpenGuildInvite](https://discord.com/developers/docs/developer-tools/game-sdk#openguildinvite)
  * 
  * This function opens the overlay modal for joining a Discord guild, given its invite code.
  * 
@@ -123,7 +123,7 @@
 
 /**
  * @function Discord_Overlay_OpenVoiceSettings
- * @desc **Discord Function:** [OpenVoiceSettings](https://discord.com/developers/docs/game-sdk/overlay#openvoicesettings)
+ * @desc **Discord Function:** [OpenVoiceSettings](https://discord.com/developers/docs/developer-tools/game-sdk#openvoicesettings)
  * 
  * This function opens the overlay widget for voice settings for the currently connected application. These settings are unique to each user within the context of your application. That means that a user can have different favorite voice settings for each of their games!
  * 
@@ -161,7 +161,7 @@
 
 /**
  * @function Discord_Overlay_SetLocked
- * @desc **Discord Function:** [SetLocked](https://discord.com/developers/docs/game-sdk/overlay#setlocked)
+ * @desc **Discord Function:** [SetLocked](https://discord.com/developers/docs/developer-tools/game-sdk#setlocked)
  * 
  * This function locks or unlocks input in the overlay. Calling `Discord_Overlay_SetLocked(true)` will also close any modals in the overlay or in-app from things like IAP purchase flows and disallow input.
  * 

--- a/docs/Overlay.js
+++ b/docs/Overlay.js
@@ -1,0 +1,198 @@
+/**
+ * @module overlay
+ * @title Overlay
+ * @desc **Discord SDK:** [Overlay](https://discord.com/developers/docs/game-sdk/overlay)
+ * 
+ * @section_func
+ * @ref Discord_Overlay_OpenActivityInvite
+ * @ref Discord_Overlay_IsEnabled
+ * @ref Discord_Overlay_IsLocked
+ * @ref Discord_Overlay_OpenGuildInvite
+ * @ref Discord_Overlay_OpenVoiceSettings
+ * @ref Discord_Overlay_SetLocked
+ * @section_end
+ * 
+ * @module_end
+ */
+
+
+// Functions
+
+/**
+ * @function Discord_Overlay_OpenActivityInvite
+ * @desc **Discord Function:** [OpenActivityInvite](https://discord.com/developers/docs/game-sdk/overlay#openactivityinvite)
+ * 
+ * This function opens the overlay modal for sending game invitations to users, channels, and servers. If you do not have a valid activity with all the required fields, this call will error. See [Activity Action Field Requirements](https://discord.com/developers/docs/game-sdk/activities#activity-action-field-requirements) for the fields required to have join and spectate invites function properly.
+ * 
+ * @param {Discord_ActivityActionType} value What type of invite to send
+ * 
+ * @example 
+ * ```gml
+ * Discord_Overlay_OpenActivityInvite(Discord_ActivityActionType_Spectate);
+ * ```
+ * 
+ * The code sample above triggers an activity invite overlay that can be listened for inside an ${event.social}.
+ * 
+ * ```gml
+ * if (async_load[? "type"] == "Discord_Overlay_OpenActivityInvite")
+ * {
+ *     if (async_load[? "result"] == Discord_OK)
+ *     {
+ *         show_debug_message("succeeded!");
+ *     }
+ *     else
+ *     {
+ *         show_debug_message("failed!");
+ *     }
+ * }
+ * ```
+ * The code above matches the response against the correct event **type** and logs the success of the task.
+ * @func_end
+ */
+
+
+/**
+ * @function Discord_Overlay_IsEnabled
+ * @desc **Discord Function:** [IsEnabled](https://discord.com/developers/docs/game-sdk/overlay#isenabled)
+ * 
+ * This function checks whether the user has the overlay enabled or disabled. If the overlay is disabled, all the functionality in this manager will still work. The calls will instead focus the Discord client and show the modal there instead.
+ * 
+ * @returns {bool}
+ * 
+ * @example 
+ * ```gml
+ * var _overlay_is_enabled = Discord_Overlay_IsEnabled();
+ * ```
+ * @func_end
+ */
+
+
+/**
+ * @function Discord_Overlay_IsLocked
+ * @desc **Discord Function:** [IsLocked](https://discord.com/developers/docs/game-sdk/overlay#islocked)
+ * 
+ * This function checks if the overlay is currently locked or unlocked.
+ * 
+ * @returns {bool}
+ * 
+ * @example 
+ * ```gml
+ * var _overlay_is_locked = Discord_Overlay_IsLocked();
+ * ```
+ * @func_end
+ */
+
+
+/**
+ * @function Discord_Overlay_OpenGuildInvite
+ * @desc **Discord Function:** [OpenGuildInvite](https://discord.com/developers/docs/game-sdk/overlay#openguildinvite)
+ * 
+ * This function opens the overlay modal for joining a Discord guild, given its invite code.
+ * 
+ * @param {string} code The server invitation code
+ * 
+ * @event social
+ * @member {real} result The result code of the async request
+ * @member {string} type The string `"Discord_Overlay_OpenGuildInvite"`
+ * @event_end
+ * 
+ * @example 
+ * ```gml
+ * identifier = Discord_Overlay_OpenGuildInvite();
+ * ```
+ * The code above saves the identifier that can be used inside an ${event.social}.
+ * 
+ * ```gml
+ * if (async_load[? "identifier"] == identifier)
+ * if (async_load[? "type"] == "Discord_Overlay_OpenGuildInvite")
+ * {
+ *     if (async_load[? "status"] == Discord_OK)
+ *     {
+ *         show_debug_message(async_load[? "type"] + " succeeded!");
+ *     }
+ *     else
+ *     {
+ *          show_debug_message(async_load[? "type"] + " failed: " + async_load[? "status_message"]);
+ *     }
+ * }
+ * ```
+ * The code above matches the response against the correct event **type** and logs the success of the task.
+ * @func_end
+ */
+
+
+/**
+ * @function Discord_Overlay_OpenVoiceSettings
+ * @desc **Discord Function:** [OpenVoiceSettings](https://discord.com/developers/docs/game-sdk/overlay#openvoicesettings)
+ * 
+ * This function opens the overlay widget for voice settings for the currently connected application. These settings are unique to each user within the context of your application. That means that a user can have different favorite voice settings for each of their games!
+ * 
+ * @event social
+ * @member {real} result The result code of the async request
+ * @member {boolean} success Whether the request was successful
+ * @member {string} type The string `"Discord_Overlay_OpenVoiceSettings"`
+ * @event_end
+ * 
+ * @example 
+ * ```gml
+ * identifier = Discord_Overlay_OpenVoiceSettings();
+ * ```
+ * 
+ * The code sample above saves the identifier that can be used inside an ${event.social}.
+ * 
+ * ```gml
+ * if (async_load[? "type"] == "Discord_Overlay_OpenVoiceSettings")
+ * if (async_load[? "identifier"] == identifier)
+ * {
+ *     if (async_load[? "status"] == Discord_OK)
+ *     {
+ *         show_debug_message(async_load[? "type"] + " succeeded!");
+ *     }
+ *     else
+ *     {
+ *          show_debug_message(async_load[? "type"] + " failed: " + async_load[? "status_message"]);
+ *     }
+ * }
+ * ```
+ * The code above matches the response against the correct event **type** and logs the success of the task.
+ * @func_end
+ */
+
+
+/**
+ * @function Discord_Overlay_SetLocked
+ * @desc **Discord Function:** [SetLocked](https://discord.com/developers/docs/game-sdk/overlay#setlocked)
+ * 
+ * This function locks or unlocks input in the overlay. Calling `Discord_Overlay_SetLocked(true)` will also close any modals in the overlay or in-app from things like IAP purchase flows and disallow input.
+ * 
+ * @param {bool} value Whether to lock (`true`) or unlocked (`false`) the overlay
+ * 
+ * @returns {real}
+ * 
+ * @event social
+ * @member {real} id The asynchronous request ID
+ * @member {string} type The string `"Discord_Overlay_SetLocked"`
+ * @event_end
+ * 
+ * @example 
+ * ```gml
+ * identifier = Discord_Overlay_SetLocked();
+ * ```
+ * The code above saves the identifier that can be used inside an ${event.social}.
+ * 
+ * ```gml
+ * if (async_load[? "type"] == "Discord_Overlay_SetLocked")
+ * if (async_load[? "identifier"] == identifier)
+ * {
+ *     if (async_load[? "status"] == Discord_OK)
+ *     {
+ *         show_debug_message(async_load[? "type"] + " succeeded!");
+ *     }
+ *     else
+ *     {
+ *          show_debug_message(async_load[? "type"] + " failed: " + async_load[? "status_message"]);
+ *     }
+ * }
+ * ```
+ * @func_end
+ */

--- a/docs/Quick_Start_Guide.md
+++ b/docs/Quick_Start_Guide.md
@@ -1,10 +1,10 @@
+@title Quick Start Guide
+
 # Quick Start Guide
 
 This guide describes the required steps to set up a GameMaker project for use with the Discord extension.
 
-/**
- * @function Discord
- * @desc **Discord Function:** []() SDK Installation
+## Discord SDK Installation
 
 1. Download the Discord SDK from the website: https://discord.com/developers/docs/game-sdk/sdk-starter-guide#step-1-get-the-thing
 2. Unzip the contents of the ZIP file: 
@@ -14,20 +14,16 @@ This guide describes the required steps to set up a GameMaker project for use wi
        - Discord_sdk
     2. If you plan to use the SDK in multiple projects, it might be better to place it somewhere else, and change the **SDK Path** extension option.
 
-/**
- * @function Extension
- * @desc **Discord Function:** []() Configuration
+## Extension Configuration
 
 1. Set the **SDK Path** extension option to the location where you installed the extension. The default value is `"../discord_game_sdk/"`. Note that this path is *relative* to the project's `.yyp` file.
-2. Enter the application ID of your application in the **Application ID** field. The extension will not work if this value is set to 0 (the initial setting).  
+2. Enter the application ID of your application in the **Application ID** field. The extension will not work if this value is set to 0 (the initial setting).
 You can create a Discord application and retrieve its ID on the [Applications page in the Developer Portal](https://discord.com/developers/applications).
 3. Set the **Log Level** to 2. This log level outputs all available debug information. In case of an issue with the extension, you should provide this output with your request.
 
-/**
- * @function Running
- * @desc **Discord Function:** []() a Game with the Extension
+## Running a Game with the Extension
 
-In order to run a game with the Discord extension, Discord must already be running. If Discord isn't running yet, the current run of your game will fail and will attempt to start Discord. The following error message is shown in [The Output Window](https://manual.yoyogames.com/Introduction/The_Output_Window.htm) in that case: 
+By default, in order to run a game with the Discord extension, Discord must already be running. If Discord isn't running yet, the current run of your game will fail and will attempt to start Discord. The following error message is shown in [The Output Window](https://manual.gamemaker.io/monthly/en/Introduction/The_Output_Window.htm) in that case: 
 
 ```
 FAILED: Run Program Complete
@@ -37,29 +33,25 @@ For the details of why this build failed, please review the whole log above and 
 The game will not restart automatically after doing this, however, and you will need to manually run the game again, after Discord has properly started.
 So the most convenient way to test your game with the Discord extension is to keep Discord open the entire time.
 
-/**
- * @function Basic
- * @desc **Discord Function:** []() Project Code
+## Basic Project Code
 
-The first thing to do is setting up the Discord extension using [`Discord_Core_Create`](Core#discord_core_create): 
+The first thing to do is setting up the Discord extension using ${function.Discord_Core_Create}: 
 
 ```gml
 var _applicationId = int64(extension_get_option_value("Discord", "appId"));
 Discord_Core_Create(_applicationId);
 ```
-The function requires the **Application ID** set earlier, which you can retrieve from the extension using the built-in function `extension_get_option_value`.
+The function requires the **Application ID** set earlier, which you can retrieve from the extension using the built-in function ${function.extension_get_option_value}.
 
-The next thing is to run the callbacks [`Discord_Core_RunCallbacks`](Core#discord_core_runcallbacks) every step. This can go in e.g. an object's Step event: 
+The next thing is to run the callbacks ${function.Discord_Core_RunCallbacks} every step. This can go in e.g. an object's ${event.step}: 
 
 ```gml
 /// @desc Step Event
 Discord_Core_RunCallbacks();
 ```
 
-/**
- * @function Changes
- * @desc **Discord Function:** []() to Current User
+## Changes to Current User
 
-Whenever the current connected user changes something in Discord (i.e. their avatar, username, or something else), the data in the [`User`](Users#user) struct should also be changed to reflect these changes in your game.
+Whenever the current connected user changes something in Discord (i.e. their avatar, username, or something else), the data in the ${struct.User} struct should also be changed to reflect these changes in your game.
 
-To be notified about these changes, you should listen for an ${event.social} of type [`Discord_Users_OnCurrentUserUpdate`](Users#discord_users_oncurrentuserupdate) and update the user data by making a new call to [`Discord_Users_GetCurrentUser`](Users#discord_users_getcurrentuser) when this type of event occurs.
+To be notified about these changes, you should listen for an ${event.social} of type `"Discord_Users_OnCurrentUserUpdate"` and update the user data by making a new call to ${function.Discord_Users_GetCurrentUser} when this type of event occurs.

--- a/docs/Quick_Start_Guide.md
+++ b/docs/Quick_Start_Guide.md
@@ -1,0 +1,65 @@
+# Quick Start Guide
+
+This guide describes the required steps to set up a GameMaker project for use with the Discord extension.
+
+/**
+ * @function Discord
+ * @desc **Discord Function:** []() SDK Installation
+
+1. Download the Discord SDK from the website: https://discord.com/developers/docs/game-sdk/sdk-starter-guide#step-1-get-the-thing
+2. Unzip the contents of the ZIP file: 
+    1. If you will only use the Discord SDK in a single project then the contents can be extracted in a directory relative to that project, e.g.: 
+       - my_gamemaker_project
+         - my_gamemaker_project.yyp
+       - Discord_sdk
+    2. If you plan to use the SDK in multiple projects, it might be better to place it somewhere else, and change the **SDK Path** extension option.
+
+/**
+ * @function Extension
+ * @desc **Discord Function:** []() Configuration
+
+1. Set the **SDK Path** extension option to the location where you installed the extension. The default value is `"../discord_game_sdk/"`. Note that this path is *relative* to the project's `.yyp` file.
+2. Enter the application ID of your application in the **Application ID** field. The extension will not work if this value is set to 0 (the initial setting).  
+You can create a Discord application and retrieve its ID on the [Applications page in the Developer Portal](https://discord.com/developers/applications).
+3. Set the **Log Level** to 2. This log level outputs all available debug information. In case of an issue with the extension, you should provide this output with your request.
+
+/**
+ * @function Running
+ * @desc **Discord Function:** []() a Game with the Extension
+
+In order to run a game with the Discord extension, Discord must already be running. If Discord isn't running yet, the current run of your game will fail and will attempt to start Discord. The following error message is shown in [The Output Window](https://manual.yoyogames.com/Introduction/The_Output_Window.htm) in that case: 
+
+```
+FAILED: Run Program Complete
+For the details of why this build failed, please review the whole log above and also see your Compile Errors window.
+```
+
+The game will not restart automatically after doing this, however, and you will need to manually run the game again, after Discord has properly started.
+So the most convenient way to test your game with the Discord extension is to keep Discord open the entire time.
+
+/**
+ * @function Basic
+ * @desc **Discord Function:** []() Project Code
+
+The first thing to do is setting up the Discord extension using [`Discord_Core_Create`](Core#discord_core_create): 
+
+```gml
+var _applicationId = int64(extension_get_option_value("Discord", "appId"));
+Discord_Core_Create(_applicationId);
+```
+The function requires the **Application ID** set earlier, which you can retrieve from the extension using the built-in function `extension_get_option_value`.
+
+The next thing is to run the callbacks [`Discord_Core_RunCallbacks`](Core#discord_core_runcallbacks) every step. This can go in e.g. an object's Step event: 
+
+```gml
+/// @desc Step Event
+Discord_Core_RunCallbacks();
+```
+
+/**
+ * @function Changes
+ * @desc **Discord Function:** []() to Current User
+
+Whenever the current connected user changes something in Discord (i.e. their avatar, username, or something else), the data in the [`User`](Users#user) struct should also be changed to reflect these changes in your game.
+
+To be notified about these changes, you should listen for an ${event.social} of type [`Discord_Users_OnCurrentUserUpdate`](Users#discord_users_oncurrentuserupdate) and update the user data by making a new call to [`Discord_Users_GetCurrentUser`](Users#discord_users_getcurrentuser) when this type of event occurs.

--- a/docs/Relationships.js
+++ b/docs/Relationships.js
@@ -1,0 +1,165 @@
+/**
+ * @module relationships
+ * @title Relationships
+ * 
+ * @section_func
+ * @ref Discord_Relationships_Filter
+ * @ref Discord_Relationships_Count
+ * @ref Discord_Relationships_Get
+ * @ref Discord_Relationships_GetAt
+ * @section_end
+ * 
+ * @section_struct
+ * @ref Relationship
+ * @section_end
+ * 
+ * @section_const
+ * @ref Discord_RelationshipType
+ * @section_end
+ * 
+ * @module_end
+ */
+
+// Functions
+
+/**
+ * @function Discord_Relationships_Filter
+ * @desc **Discord Function:** [Filter](https://discord.com/developers/docs/game-sdk/relationships#filter)
+ * 
+ * This function performs a query over the relationships of the current user selection only the ones that match the given type.
+ * 
+ * @param {constant.Discord_RelationshipType} type The type of relationship to filter when performing the query
+ * 
+ * @example 
+ * ```gml
+ * Discord_Relationship_Filter(Discord_RelationshipType_Friend);
+ * count = Discord_Relationships_Count();
+ * for(var a = 0 ; a < count ; a++)
+ * {
+ *     var _struct = Discord_Relationships_GetAt(a);
+ *     type = _struct.type;
+ *     username = _struct.username;
+ *     avatar = _struct.avatar;
+ *     id = _struct.id;
+ *     bot = _struct.bot;
+ *     discriminator = _struct.discriminator;
+ *     //Do something each loop with this information..
+ * }
+ * ```
+ * @func_end
+ */
+
+
+/**
+ * @function Discord_Relationships_Count
+ * @desc **Discord Function:** [Count](https://discord.com/developers/docs/game-sdk/relationships#count)
+ * 
+ * This function gets the number of relationships that match your previous query.
+ * 
+ * @returns [real](https://manual.yoyogames.com/GameMaker_Language/GML_Overview/Data_Types.htm)
+ * 
+ * @example 
+ * ```gml
+ * Discord_Relationships_Filter(Discord_Relationship_Filter_Friend);
+ * count = Discord_Relationships_Count();
+ * for(var a = 0 ; a < count ; a++)
+ * {
+ *     var _struct = Discord_Relationships_GetAt(a);
+ *     type = _struct.type;
+ *     username = _struct.username;
+ *     avatar = _struct.avatar;
+ *     id = _struct.id;
+ *     bot = _struct.bot;
+ *     discriminator = _struct.discriminator;
+ *     //Do something each loop with this information..
+ * }
+ * ```
+ * @func_end
+ */
+
+/**
+ * @function Discord_Relationships_Get
+ * @desc **Discord Function:** [Get](https://discord.com/developers/docs/game-sdk/relationships#get)
+ * 
+ * This function gets the relationship between the current user and a given user by ID.
+ * 
+ * @param {int64} userId User identifier
+ * 
+ * @returns {struct.Relationship}
+ * 
+ * @example 
+ * ```gml
+ * var _struct = Discord_Relationships_Get(userId);
+ * type = _struct.type;
+ * username = _struct.username;
+ * avatar = _struct.avatar;
+ * userId = _struct.userId;
+ * bot = _struct.bot;
+ * discriminator = _struct.discriminator;
+ * ```
+ * @func_end
+ */
+
+/**
+ * @function Discord_Relationships_GetAt
+ * @desc **Discord Function:** [GetAt](https://discord.com/developers/docs/game-sdk/relationships#getat)
+ * This function gets the relationship at a given index when iterating over a list of relationships.
+ * 
+ * [[Warning: This function requires a previous call to the function ${function.Discord_Relationships_Filter}.
+ * 
+ * @param index Index of the relationship
+ * 
+ * @returns {struct.Relationship}
+ * 
+ * @example 
+ * ```gml
+ * Discord_Relationships_Filter(Discord_RelationshipType_Friend);
+ * count = Discord_Relationships_Count();
+ * for(var a = 0 ; a < count ; a++)
+ * {
+ *     var _struct = Discord_Relationships_GetAt(a);
+ *     type = _struct.type;
+ *     username = _struct.username;
+ *     avatar = _struct.avatar;
+ *     userId = _struct.id;
+ *     bot = _struct.bot;
+ *     discriminator = _struct.discriminator;
+ *    
+ *     //Do something each loop with this information..
+ * }
+ * ```
+ * @func_end
+ */
+
+// Structs
+
+/**
+ * @struct Relationship
+ * @desc **Discord Struct:** [Relationship Struct](https://discord.com/developers/docs/game-sdk/relationships#data-models-relationship-struct)
+ * 
+ * This struct contains information about the user with whom the connected user has a relationship. It includes the type of relationship with the user, the other user's presence and details on the other user.
+ * The details on the other user are stored in the `user` field, which holds a struct with: the username of the user (the name displayed on their profile and in chat messages), the `avatar` field (the URL of the user's avatar image), the `userId` field (the unique user ID assigned by Discord), the `bot` field (a boolean value indicating whether the user is a bot account or a human user) and the `discriminator` field (contains the four-digit number that appears after the username, used to distinguish between users with the same username).
+ * 
+ * Here is a table summarizing the fields in the "relationship" structure and their meanings:
+ * 
+ * @member {constant.Discord_RelationshipType} type The username of the user, which is the name displayed on their profile and in chat messages.
+ * @member {struct.user} user The user the relationship is for.
+ * @member {struct.Presence} presence That user's current presence
+ * @struct_end
+ */
+
+
+// Constants
+
+/**
+ * @const Discord_RelationshipType
+ * @desc **Discord Function:** [RelationshipType Enum](https://discord.com/developers/docs/game-sdk/relationships#data-models-relationshiptype-enum)
+ * 
+ * @member Discord_RelationshipType_None 0 User has no intrinsic relationship on Discord.
+ * @member Discord_RelationshipType_Friend 1 User is a friend of the connected user, and they can see each other's online status, send direct messages, etc.
+ * @member Discord_RelationshipType_Blocked 2 User is blocked by the connected user and cannot interact with them on Discord.
+ * @member Discord_RelationshipType_PendingIncoming 3 User has sent a friend request to the connected user, but it has not yet been accepted.
+ * @member Discord_RelationshipType_PendingOutgoing 4 Connected user has sent a friend request to the other user, but it has not yet been accepted.
+ * @member Discord_RelationshipType_Implicit 5 Users are not friends but interact with each other often, based on frequency and recency of interactions.
+ * @const_end
+ */

--- a/docs/Relationships.js
+++ b/docs/Relationships.js
@@ -143,7 +143,7 @@
  * Here is a table summarizing the fields in the "relationship" structure and their meanings:
  * 
  * @member {constant.Discord_RelationshipType} type The username of the user, which is the name displayed on their profile and in chat messages.
- * @member {struct.user} user The user the relationship is for.
+ * @member {struct.User} user The user the relationship is for.
  * @member {struct.Presence} presence That user's current presence
  * @struct_end
  */

--- a/docs/Relationships.js
+++ b/docs/Relationships.js
@@ -1,6 +1,9 @@
 /**
  * @module relationships
  * @title Relationships
+ * @desc **Discord SDK:** [Relationships](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Relationships.md#relationships)
+ * 
+ * [[Warning: The Game SDK's Relationships functionality has been deprecated by Discord.]]
  * 
  * @section_func
  * @ref Discord_Relationships_Filter
@@ -24,7 +27,7 @@
 
 /**
  * @function Discord_Relationships_Filter
- * @desc **Discord Function:** [Filter](https://discord.com/developers/docs/game-sdk/relationships#filter)
+ * @desc **Discord Function:** [Filter](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Relationships.md#filter)
  * 
  * This function performs a query over the relationships of the current user selection only the ones that match the given type.
  * 
@@ -52,7 +55,7 @@
 
 /**
  * @function Discord_Relationships_Count
- * @desc **Discord Function:** [Count](https://discord.com/developers/docs/game-sdk/relationships#count)
+ * @desc **Discord Function:** [Count](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Relationships.md#count)
  * 
  * This function gets the number of relationships that match your previous query.
  * 
@@ -79,7 +82,7 @@
 
 /**
  * @function Discord_Relationships_Get
- * @desc **Discord Function:** [Get](https://discord.com/developers/docs/game-sdk/relationships#get)
+ * @desc **Discord Function:** [Get](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Relationships.md#get)
  * 
  * This function gets the relationship between the current user and a given user by ID.
  * 
@@ -102,10 +105,11 @@
 
 /**
  * @function Discord_Relationships_GetAt
- * @desc **Discord Function:** [GetAt](https://discord.com/developers/docs/game-sdk/relationships#getat)
+ * @desc **Discord Function:** [GetAt](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Relationships.md#getat)
+ * 
  * This function gets the relationship at a given index when iterating over a list of relationships.
  * 
- * [[Warning: This function requires a previous call to the function ${function.Discord_Relationships_Filter}.
+ * [[Warning: This function requires a previous call to the function ${function.Discord_Relationships_Filter}.]]
  * 
  * @param index Index of the relationship
  * 
@@ -135,7 +139,7 @@
 
 /**
  * @struct Relationship
- * @desc **Discord Struct:** [Relationship Struct](https://discord.com/developers/docs/game-sdk/relationships#data-models-relationship-struct)
+ * @desc **Discord Struct:** [Relationship Struct](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Relationships.md#relationship-struct)
  * 
  * This struct contains information about the user with whom the connected user has a relationship. It includes the type of relationship with the user, the other user's presence and details on the other user.
  * The details on the other user are stored in the `user` field, which holds a struct with: the username of the user (the name displayed on their profile and in chat messages), the `avatar` field (the URL of the user's avatar image), the `userId` field (the unique user ID assigned by Discord), the `bot` field (a boolean value indicating whether the user is a bot account or a human user) and the `discriminator` field (contains the four-digit number that appears after the username, used to distinguish between users with the same username).
@@ -153,7 +157,7 @@
 
 /**
  * @const Discord_RelationshipType
- * @desc **Discord Function:** [RelationshipType Enum](https://discord.com/developers/docs/game-sdk/relationships#data-models-relationshiptype-enum)
+ * @desc **Discord Function:** [RelationshipType Enum](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Relationships.md#relationshiptype-enum)
  * 
  * @member Discord_RelationshipType_None 0 User has no intrinsic relationship on Discord.
  * @member Discord_RelationshipType_Friend 1 User is a friend of the connected user, and they can see each other's online status, send direct messages, etc.

--- a/docs/Users.js
+++ b/docs/Users.js
@@ -17,6 +17,7 @@
  * 
  * @section_const
  * @ref Discord_PremiumType
+ * @ref Discord_UserStatus
  * @section_end
  * 
  * @module_end
@@ -83,7 +84,7 @@
  * @event social
  * @member {real} result The result code of the async request
  * @member {string} type The string `"Discord_User_GetUser"`
- * @member {struct.user} user The user data
+ * @member {struct.User} user The user data
  * @event_end
  * 
  * @example
@@ -157,7 +158,7 @@
  * The Presence struct contains information about a user's current online status and activity.
  * 
  * @member {constant.Discord_UserStatus} Status The user's current online status.
- * @member {constant.Activity} Activity The user's current activity, if any.
+ * @member {struct.Activity} Activity The user's current activity, if any.
  * 
  * @struct_end
  */

--- a/docs/Users.js
+++ b/docs/Users.js
@@ -1,7 +1,7 @@
 /**
  * @module users
  * @title Users
- * @desc **Discord SDK:** [Users](https://discord.com/developers/docs/game-sdk/users)
+ * @desc **Discord SDK:** [Users](https://discord.com/developers/docs/developer-tools/game-sdk#users)
  * 
  * @section_func
  * @ref Discord_Users_GetCurrentUser
@@ -26,7 +26,7 @@
 
 /**
  * @function Discord_Users_GetCurrentUser
- * @desc **Discord Function:** [GetCurrentUser](https://discord.com/developers/docs/game-sdk/users#getcurrentuser)
+ * @desc **Discord Function:** [GetCurrentUser](https://discord.com/developers/docs/developer-tools/game-sdk#getcurrentuser)
  * 
  * This function fetches information about the currently connected user account.
  * 
@@ -46,7 +46,7 @@
 
 /**
  * @func Discord_Users_GetCurrentUserPremiumType
- * @desc **Discord Function:** [GetCurrentUserPremiumType](https://discord.com/developers/docs/game-sdk/users#getcurrentuserpremiumtype)
+ * @desc **Discord Function:** [GetCurrentUserPremiumType](https://discord.com/developers/docs/developer-tools/game-sdk#getcurrentuserpremiumtype)
 
  * This function gets the ${constant.Discord_PremiumType} for the currently connected user.
 
@@ -75,7 +75,7 @@
 
 /**
  * @func Discord_Users_GetUser
- * @desc **Discord Function:** [GetUser](https://discord.com/developers/docs/game-sdk/users#getuser)
+ * @desc **Discord Function:** [GetUser](https://discord.com/developers/docs/developer-tools/game-sdk#getuser)
  * 
  * This function gets user information for a given ID.
  * 
@@ -113,18 +113,17 @@
  * The code above matches the response against the correct event **type** and logs the success of the task.
  * 
  * @func_end
- * */
+ */
 
 
 /**
  * @func Discord_Users_SetCurrentUsername
  * @desc **Discord Function:** N/A
 
- * Set the current user's username information.
+ * This function sets the current user's username information.
  *
  * @param {string} username The new username to be applied to the current user.
  * 
- * @returns {string}
  * @example
  * 
  * ```gml
@@ -138,7 +137,7 @@
 
 /**
  * @struct User
- * @desc **Discord Struct:** [User Structure](https://discord.com/developers/docs/resources/user#user-object-user-structure)
+ * @desc **Discord Struct:** [User Structure](https://discord.com/developers/docs/developer-tools/game-sdk#user-struct)
  * 
  * This struct stores information about a Discord user.
  * 
@@ -153,7 +152,7 @@
 
 /**
  * @struct Presence
- * @desc **Discord Struct:** [Presence Struct](https://discord.com/developers/docs/game-sdk/relationships#data-models-presence-struct)
+ * @desc **Discord Struct:** [Presence Struct](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Relationships.md#presence-struct)
  * 
  * The Presence struct contains information about a user's current online status and activity.
  * 
@@ -168,7 +167,7 @@
 
 /**
  * @const Discord_UserStatus
- * @desc **Discord Enum:** [Status Enum](https://discord.com/developers/docs/game-sdk/relationships#data-models-status-enum)
+ * @desc **Discord Enum:** [Status Enum](https://github.com/discord/discord-api-docs/blob/legacy-gamesdk/docs/game_sdk/Relationships.md#status-enum)
  * 
  * The Status enum represents the online status of a user on Discord.
  * 
@@ -183,7 +182,7 @@
 
 /**
  * @const Discord_PremiumType
- * @desc **Discord Enum:** [PremiumType Enum](https://discord.com/developers/docs/game-sdk/users#data-models-premiumtype-enum)
+ * @desc **Discord Enum:** [PremiumType Enum](https://discord.com/developers/docs/developer-tools/game-sdk#premiumtype-enum)
  * 
  * The PremiumType enum describes the type of Nitro subscription a user has. It has the following values and descriptions: 
  * 

--- a/docs/Users.js
+++ b/docs/Users.js
@@ -1,0 +1,195 @@
+/**
+ * @module users
+ * @title Users
+ * @desc **Discord SDK:** [Users](https://discord.com/developers/docs/game-sdk/users)
+ * 
+ * @section_func
+ * @ref Discord_Users_GetCurrentUser
+ * @ref Discord_Users_GetCurrentUserPremiumType
+ * @ref Discord_Users_GetUser
+ * @ref Discord_Users_SetCurrentUsername
+ * @section_end
+ * 
+ * @section_struct
+ * @ref User
+ * @ref Presence
+ * @section_end
+ * 
+ * @section_const
+ * @ref Discord_PremiumType
+ * @section_end
+ * 
+ * @module_end
+
+// Functions
+
+/**
+ * @function Discord_Users_GetCurrentUser
+ * @desc **Discord Function:** [GetCurrentUser](https://discord.com/developers/docs/game-sdk/users#getcurrentuser)
+ * 
+ * This function fetches information about the currently connected user account.
+ * 
+ * @returns {struct.User}
+ * 
+ * @example
+ * ```gml
+ * var _struct = Discord_User_GetCurrentUser();
+ * username = _struct.username;
+ * bot = _struct.bot;
+ * userId = _struct.userId;
+ * discriminator = _struct.discriminator;
+ * ```
+ * @func_end
+ */
+
+
+/**
+ * @func Discord_Users_GetCurrentUserPremiumType
+ * @desc **Discord Function:** [GetCurrentUserPremiumType](https://discord.com/developers/docs/game-sdk/users#getcurrentuserpremiumtype)
+
+ * This function gets the ${constant.Discord_PremiumType} for the currently connected user.
+
+ * @returns {constant.Discord_PremiumType}
+ * @example
+ * ```gml
+ * switch(Discord_User_GetCurrentUserPremiumType())
+ * {
+ *    case Discord_PremiumType_None:
+ *        show_debug_message("User is not a Nitro subscriber");
+ *    break;
+ * 
+ *    case Discord_PremiumType_Tier1:
+ *        show_debug_message("User has Nitro Classic");
+ *    break;
+ * 
+ *    case Discord_PremiumType_Tier2:
+ *        show_debug_message("User has Nitro");
+ *    break;
+ * }
+ * ```
+ * 
+ * @func_end
+ */
+
+
+/**
+ * @func Discord_Users_GetUser
+ * @desc **Discord Function:** [GetUser](https://discord.com/developers/docs/game-sdk/users#getuser)
+ * 
+ * This function gets user information for a given ID.
+ * 
+ * @param {int64} userId Identifier of the user
+ * 
+ * @event social
+ * @member {real} result The result code of the async request
+ * @member {string} type The string `"Discord_User_GetUser"`
+ * @member {struct.user} user The user data
+ * @event_end
+ * 
+ * @example
+ * 
+ * ```gml
+ * Discord_Users_GetUser(userId);
+ * ```
+ * 
+ * The code sample above saves the identifier that can be used inside an ${event.social}.
+ * 
+ * ```gml
+ * if (async_load[? "type"] == "Discord_User_GetUser")
+ * {
+ *     if (async_load[? "result"] == Discord_OK)
+ *     {
+ *         show_debug_message(async_load[? "type"] + " succeeded!");
+ *         show_debug_message(async_load[? "user"]);
+ *     }
+ *     else
+ *     {
+ *         show_debug_message(async_load[? "type"] + " failed!");
+ *     }
+ * }
+ * ```
+ * 
+ * The code above matches the response against the correct event **type** and logs the success of the task.
+ * 
+ * @func_end
+ * */
+
+
+/**
+ * @func Discord_Users_SetCurrentUsername
+ * @desc **Discord Function:** N/A
+
+ * Set the current user's username information.
+ *
+ * @param {string} username The new username to be applied to the current user.
+ * 
+ * @returns {string}
+ * @example
+ * 
+ * ```gml
+ * Discord_User_SetCurrentUsername("SuperUser");
+ * ```
+ * The code sample above will update the current user's username.
+ * @func_end
+ */
+
+// Structs
+
+/**
+ * @struct User
+ * @desc **Discord Struct:** [User Structure](https://discord.com/developers/docs/resources/user#user-object-user-structure)
+ * 
+ * This struct stores information about a Discord user.
+ * 
+ * @member {int64} userId The unique ID assigned to the user by Discord.
+ * @member {string} username The username of the user, which is the name displayed on their profile and in chat messages.
+ * @member {string} discriminator The four-digit number that appears after the username, used to distinguish between users with the same username.
+ * @member {string} avatar The hash of the user's avatar image.
+ * @member {bool} bot A boolean value indicating whether the user is a bot account or a human user.
+ * 
+ * @struct_end
+ */
+
+/**
+ * @struct Presence
+ * @desc **Discord Struct:** [Presence Struct](https://discord.com/developers/docs/game-sdk/relationships#data-models-presence-struct)
+ * 
+ * The Presence struct contains information about a user's current online status and activity.
+ * 
+ * @member {constant.Discord_UserStatus} Status The user's current online status.
+ * @member {constant.Activity} Activity The user's current activity, if any.
+ * 
+ * @struct_end
+ */
+
+
+// Constants
+
+/**
+ * @const Discord_UserStatus
+ * @desc **Discord Enum:** [Status Enum](https://discord.com/developers/docs/game-sdk/relationships#data-models-status-enum)
+ * 
+ * The Status enum represents the online status of a user on Discord.
+ * 
+ * @member Discord_UserStatus_Offline 0 The user is offline.
+ * @member Discord_UserStatus_Online 1 The user is online.
+ * @member Discord_UserStatus_Idle 2 The user is idle (i.e., away from keyboard or has been inactive for a certain amount of time).
+ * @member Discord_UserStatus_DoNotDisturb 3 The user is in "do not disturb" mode, indicating that they do not want to be disturbed or receive notifications.
+ * 
+ * @const_end
+ */
+
+
+/**
+ * @const Discord_PremiumType
+ * @desc **Discord Enum:** [PremiumType Enum](https://discord.com/developers/docs/game-sdk/users#data-models-premiumtype-enum)
+ * 
+ * The PremiumType enum describes the type of Nitro subscription a user has. It has the following values and descriptions: 
+ * 
+ * @member Discord_PremiumType_None 0 Not a Nitro subscriber
+ * @member Discord_PremiumType_Tier1 1 Nitro Classic subscriber
+ * @member Discord_PremiumType_Tier2 2 Nitro subscriber
+ * @member Discord_PremiumType_Tier3 3 Nitro Basic subscriber (formerly Nitro)
+ *
+ * @const_end
+ */

--- a/docs/_Footer.md
+++ b/docs/_Footer.md
@@ -1,0 +1,1 @@
+YoYoGames ${time.year}

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,9 @@
+* ### [Discord](Home)
+* ### [Quick Start Guide](Quick_Start_Guide)
+* ### Modules
+  * ### [Core](Core)
+  * ### [Overlay](Overlay)
+  * ### [Users](Users)
+  * ### [Activities](Activities)
+  * ### [Relationships](Relationships)
+  * ### [Images](Images)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,9 +1,9 @@
-* ### [Discord](Home)
-* ### [Quick Start Guide](Quick_Start_Guide)
+* ### ${module.home}
+* ### ${page.Quick_Start_Guide}
 * ### Modules
-  * ### [Core](Core)
-  * ### [Overlay](Overlay)
-  * ### [Users](Users)
-  * ### [Activities](Activities)
-  * ### [Relationships](Relationships)
-  * ### [Images](Images)
+  * ### ${module.core}
+  * ### ${module.overlay}
+  * ### ${module.users}
+  * ### ${module.activities}
+  * ### ${module.relationships} (deprecated)
+  * ### ${module.images} (deprecated)


### PR DESCRIPTION
This PR contains the Discord extension documentation ported from the wiki to the "docs" folder format. The updated documentation includes links to the Discord documentation and warnings about parts of Discord's Game SDK being deprecated.